### PR TITLE
Add visualization for base pairs strength

### DIFF
--- a/src/plot_structure.jl
+++ b/src/plot_structure.jl
@@ -151,7 +151,9 @@ function plot_structure_makie(
     sequence::AbstractString=" "^length(structure),
     savepath::String = "",
     layout_type::Symbol=:simple,
-    colorscheme::Symbol=:lightrainbow)
+    colorscheme::Symbol=:lightrainbow,
+    linestyles::Bool=true,
+)
 
     fc = FoldCompound(sequence)
     partfn(fc)
@@ -173,12 +175,21 @@ function plot_structure_makie(
     hidespines!(ax)
 
     for (i, j) in pairs
+	if linestyles == false
+            linestyle = :solid
+        elseif all(occursin.((sequence[i], sequence[j]), "CG"))
+            linestyle = :solid
+        elseif all(occursin.((sequence[i], sequence[j]), "AUT"))
+            linestyle = :dash
+        else
+            linestyle = :dot
+        end
         lines!(
             [x_coords[i], x_coords[j]],
             [y_coords[i], y_coords[j]],
-            color = :black,
-            linestyle = :dot,
-            linewidth = 1,
+            color = (:black, 0.5),
+            linestyle = linestyle,
+            linewidth = 0.8,
         )
     end
     scatterlines!(ax, x_coords, y_coords,


### PR DESCRIPTION
GC - 3 hydrogen bonds (solid line)
AT/U - 2 hydrogen bonds (dashed line)
GU - non-canonical base pairs, less stable (dottet line)

Added optional argument `linestyles` if someone doesnt want this.